### PR TITLE
Fix CocoaPods Build issue

### DIFF
--- a/Obfuscator/Obfuscator.h
+++ b/Obfuscator/Obfuscator.h
@@ -6,7 +6,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#include <CommonCrypto/CommonCrypto.h>
 
 /*
  * Code based on these articles/code-samples:

--- a/Obfuscator/Obfuscator.m
+++ b/Obfuscator/Obfuscator.m
@@ -7,6 +7,8 @@
 
 #import "Obfuscator.h"
 
+#include <CommonCrypto/CommonCrypto.h>
+
 @interface Obfuscator ()
     @property (strong) NSString *salt;
 


### PR DESCRIPTION
This fixes the issue building with CocoaPods in issue #2.

The `#include <CommonCrypto/CommonCrypto.h>` line needed to be moved from the header file to the implementation file to remove the build error.

I've tested this in my application and it works as expected.
